### PR TITLE
#100 [docs] Add Git rules documentation

### DIFF
--- a/.cursor/rules/git-rules.mdc
+++ b/.cursor/rules/git-rules.mdc
@@ -1,0 +1,124 @@
+---
+alwaysApply: true
+---
+
+# Git Rules
+
+## Branch name
+
+`main` 과 `dev` 브랜치를 제외한 브랜치의 이름은 다음의 규칙을 따릅니다.
+
+```
+release-v{X.Y}
+epic/#{ISSUE}
+issue/#{ISSUE}-{SUMMARY}  # SUMMARY is not required.
+```
+
+## Commit messages
+
+Git 커밋 메시지는 다음의 규칙에 따라 작성합니다.
+
+```
+[<TYPE>] <Summary>
+
+- <Detail 1>
+- <Detail 2>
+
+# =============================================================================
+# Commit Message 작성 가이드
+# =============================================================================
+#
+# 🎯 TYPE 가이드:
+#   feat     : 새로운 기능 추가
+#   enhance  : 기존 기능 개선/향상
+#   refactor : 코드 리팩토링 (기능 변경 없이 코드 구조 개선)
+#   docs     : 문서 변경 (README, 주석 등)
+#   fix      : 버그 수정
+#   style    : 코드 포맷팅, 세미콜론 누락 등 (기능에 영향 없음)
+#   test     : 테스트 코드 추가/수정
+#   chore    : 빌드 프로세스, 패키지 관리자 설정 등
+#
+# 📝 작성 규칙:
+#   1. 첫 번째 줄(제목)은 50자 이내로 작성
+#   2. 제목과 본문 사이에 빈 줄 추가
+#   3. 본문은 72자마다 줄바꿈
+#   4. 제목은 영어, 본문은 한국어 또는 영어
+#   5. 제목은 명령문으로 작성 (Add, Fix, Update 등)
+#   6. 제목 끝에 마침표 없음
+#
+# 💡 예시:
+#   [feat] Add user authentication system
+#
+#   - GitHub OAuth 2.0 PKCE 플로우 구현
+#   - JWT 토큰 기반 인증 미들웨어 추가
+#   - 사용자 세션 관리 기능
+#
+# 🚫 하지 말아야 할 것:
+#   - 제목에 마침표 사용
+#   - 애매한 메시지 ("fix bug", "update code")
+#   - 한 커밋에 여러 기능 포함
+#
+# =============================================================================
+```
+
+## Pull requests
+
+### Title
+
+풀 리퀘스트의 제목은 다음의 규칙에 따라 작성합니다.
+
+```
+#<ISSUE_NUMBER> [<TYPE>] <Summary>
+
+# TYPE 가이드:
+#   feat     : 새로운 기능 추가
+#   enhance  : 기존 기능 개선/향상
+#   refactor : 코드 리팩토링 (기능 변경 없이 코드 구조 개선)
+#   docs     : 문서 변경 (README, 주석 등)
+#   fix      : 버그 수정
+#   style    : 코드 포맷팅, 세미콜론 누락 등 (기능에 영향 없음)
+#   test     : 테스트 코드 추가/수정
+#   chore    : 빌드 프로세스, 패키지 관리자 설정 등
+```
+
+### Description
+
+풀 리퀘스트의 내용은 다음의 규칙에 따라 작성합니다.
+
+```
+<!--
+PR 작성 전 한 번씩 읽어주세요.
+
+# How to write Good Commit Message
+#   1. Specify the type of commit: feat, enh, bugfix, style, docs
+#   2. Separate the subject from the body with a blank line
+#   3. Your commit message should not contain any whitespace errors
+#   4. Remove unnecessary punctuation marks
+#   5. Do not end the subject line with a period
+#   6. Capitalize the subject line and each paragraph
+#   7. Use the imperative mood in the subject line
+#   8. Use the body to explain what changes you have made and why you made them.
+#   9. Do not assume the reviewer understands what the original problem was, ensure you add it.
+#   10. Do not think your code is self-explanatory
+#   11. Follow the commit convention defined by your team
+-->
+
+## Issue?
+<!-- 관련된 GitHub issue number 를 입력해주세요.
+없다면 입력하지 않고 넘어가도 됩니다. -->
+
+## Changes?
+<!-- 이 PR 로 인해서 무엇이 변경되었는지 작성해주세요. -->
+
+## Why we need?
+<!-- 이 PR 이 왜 필요한지 작성해주세요. -->
+
+## Test?
+<!-- 어떻게 테스트했는지, 어떻게 reproduce 할 수 있는지 등 간단하게 작성해주세요. -->
+
+## CC (Optional)
+<!-- 이 PR을 확인해야 하거나 참고할 분이 있다면 멘션해주세요. -->
+
+## Anything else? (Optional)
+<!-- 스크린샷, 환경 정보, 주의사항 등 필요한 추가정보가 있다면 작성해주세요. -->
+```


### PR DESCRIPTION
## Issue?
#100

## Changes?
- Cursor Rules에 Git/GitHub 규칙 문서 추가 (.cursor/rules/git-rules.mdc)
- 브랜치 네이밍 규칙 정의 (release-v{X.Y}, epic/#{ISSUE}, issue/#{ISSUE}-{SUMMARY})
- 커밋 메시지 컨벤션 가이드 작성 (TYPE, 작성 규칙, 예시)
- PR 제목 및 본문 템플릿 정의

## Why we need?
현재 Notion에 분산되어 있는 Git/GitHub 규칙들을 중앙 집중화하여, 팀 전체가 일관된 워크플로우를 따를 수 있도록 하기 위함입니다. 새로운 기여자들도 쉽게 규칙을 이해하고 따를 수 있습니다.

## Test?
- git-rules.mdc 파일이 .cursor/rules/ 폴더에 정상적으로 추가됨
- Cursor IDE에서 규칙이 자동으로 로드되어 AI가 참조 가능함
- 브랜치 네이밍, 커밋 메시지, PR 템플릿 형식 확인

## CC (Optional)
<!-- 검토가 필요한 분을 멘션해주세요 -->

## Anything else? (Optional)
이 문서는 Cursor Rules로 작성되어 AI가 자동으로 참조할 수 있습니다. 향후 팀원들이 Git 작업 시 일관된 규칙을 따를 수 있도록 도와줍니다.