### PR TITLE
feat(masthead): mirror thakicloud.com website menu on the blog

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,33 +1,118 @@
-# Single combined browse page (the home) + language switcher.
-# Categories / Tags / Comics were merged into the home page, which filters in
-# place via ?category= and ?tags=. The "Posts" nav item was removed since the
-# whole site is one page and the masthead logo already links to it.
+# Masthead navigation — mirrors the thakicloud.com website menu so the blog
+# reads as the same site (Product ▾ / Tech Blog / Company / Contact + language).
 #
-# Arabic (ar) is disabled site-wide — the العربية option was removed from every
-# switcher. Re-enable by restoring the `العربية / /ar/` child in each list and
-# the `ar:` block, plus removing the ar excludes in _config.yml.
+# Item shapes the masthead understands:
+#   • plain link      -> title + url            (url may be absolute to thakicloud.com)
+#   • dropdown        -> title + children[]     (each child: title [+ description] [+ url])
+#                        a child WITHOUT url renders as a section header
+#   • language toggle -> title + type: language + children[] of /ko/ /en/ (+ /ar/)
+#                        (special-cased: resolves the SAME post's URL per language)
+#
+# Product links are absolute (https://thakicloud.com/...) because those pages
+# live on the main site, not the blog. "Tech Blog" points to the blog home.
+#
+# Arabic (ar) is disabled site-wide. Re-enable by restoring the العربية child in
+# each language switcher and the `ar:` block, plus the ar excludes in _config.yml.
 
-# main links (default - Korean)
+# ------- shared building blocks (YAML anchors) -------------------------------
+_product_children_en: &product_children_en
+  - title: "On-Prem AI Cloud"
+  - title: "Aegis"
+    description: "Private Cloud Platform"
+    url: "https://thakicloud.com/aegis"
+  - title: "Metis"
+    description: "AI Inference Platform"
+    url: "https://thakicloud.com/metis"
+  - title: "Maxis"
+    description: "AI Training Platform"
+    url: "https://thakicloud.com/maxis"
+  - title: "Paxis"
+    description: "Enterprise Agent Platform"
+    url: "https://thakicloud.com/paxis"
+  - title: "Capsis"
+    description: "Container Platform"
+    url: "https://thakicloud.com/capsis"
+  - title: "AI Cloud"
+  - title: "Velox"
+    description: "Bare Metal Cloud"
+    url: "https://thakicloud.com/velox"
+  - title: "Telox"
+    description: "AI Native Cloud"
+    url: "https://thakicloud.com/telox"
+
+_product_children_ko: &product_children_ko
+  - title: "On-Prem AI Cloud"
+  - title: "Aegis"
+    description: "프라이빗 클라우드 플랫폼"
+    url: "https://thakicloud.com/aegis"
+  - title: "Metis"
+    description: "AI 추론 플랫폼"
+    url: "https://thakicloud.com/metis"
+  - title: "Maxis"
+    description: "AI 학습 플랫폼"
+    url: "https://thakicloud.com/maxis"
+  - title: "Paxis"
+    description: "엔터프라이즈 에이전트 플랫폼"
+    url: "https://thakicloud.com/paxis"
+  - title: "Capsis"
+    description: "컨테이너 플랫폼"
+    url: "https://thakicloud.com/capsis"
+  - title: "AI Cloud"
+  - title: "Velox"
+    description: "베어메탈 클라우드"
+    url: "https://thakicloud.com/velox"
+  - title: "Telox"
+    description: "AI Native 클라우드"
+    url: "https://thakicloud.com/telox"
+
+# ------- main links (default - Korean) ---------------------------------------
 main:
+  - title: "제품"
+    children: *product_children_ko
+  - title: "Tech Blog"
+    url: /ko/
+  - title: "회사 소개"
+    url: "https://thakicloud.com/company"
+  - title: "문의하기"
+    url: "https://thakicloud.com/contact"
   - title: "언어"
+    type: language
     children:
       - title: "한국어"
         url: /ko/
       - title: "English"
         url: /en/
 
-# 한국어 네비게이션
+# ------- 한국어 네비게이션 -----------------------------------------------------
 ko:
+  - title: "제품"
+    children: *product_children_ko
+  - title: "Tech Blog"
+    url: /ko/
+  - title: "회사 소개"
+    url: "https://thakicloud.com/company"
+  - title: "문의하기"
+    url: "https://thakicloud.com/contact"
   - title: "언어"
+    type: language
     children:
       - title: "한국어"
         url: /ko/
       - title: "English"
         url: /en/
 
-# 영어 네비게이션
+# ------- 영어 네비게이션 -------------------------------------------------------
 en:
+  - title: "Product"
+    children: *product_children_en
+  - title: "Tech Blog"
+    url: /en/
+  - title: "Company"
+    url: "https://thakicloud.com/company"
+  - title: "Contact"
+    url: "https://thakicloud.com/contact"
   - title: "Language"
+    type: language
     children:
       - title: "한국어"
         url: /ko/

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -32,6 +32,7 @@
           {%- for link in navigation_data -%}
             <li class="masthead__menu-item">
               {% if link.children %}
+                {% if link.type == 'language' %}
                 <a href="#" class="dropdown-toggle" aria-label="{{ link.title }}" title="{{ link.title }}">
                   <span class="visually-hidden">{{ link.title }}</span>
                   <svg class="tbi" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 12a9 9 0 1 0 18 0a9 9 0 0 0 -18 0"/><path d="M3.6 9h16.8"/><path d="M3.6 15h16.8"/><path d="M11.5 3a17 17 0 0 0 0 18"/><path d="M12.5 3a17 17 0 0 1 0 18"/></svg>
@@ -66,8 +67,29 @@
                     <li><a href="{{ _target | relative_url }}"{% if child_lang == cur_lang %} class="is-active" aria-current="page"{% endif %}{% if child.description %} title="{{ child.description }}"{% endif %}>{{ child.title }}</a></li>
                   {%- endfor -%}
                 </ul>
+                {% else %}
+                {%- comment %} Generic website-menu dropdown (e.g. Product): text toggle + sectioned links to the main site. {% endcomment -%}
+                <a href="#" class="dropdown-toggle dropdown-toggle--text" aria-haspopup="true" aria-label="{{ link.title }}" title="{{ link.title }}">
+                  {{ link.title }}
+                  <svg class="tbi dropdown-caret" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 9l6 6 6 -6"/></svg>
+                </a>
+                <ul class="dropdown-menu dropdown-menu--wide">
+                  {%- for child in link.children -%}
+                    {%- if child.url -%}
+                      {%- if child.url contains '://' -%}{%- assign _href = child.url -%}{%- else -%}{%- assign _href = child.url | relative_url -%}{%- endif -%}
+                      <li><a href="{{ _href }}"{% if child.description %} title="{{ child.description }}"{% endif %}>
+                        <span class="dropdown-name">{{ child.title }}</span>
+                        {%- if child.description %}<span class="dropdown-desc">{{ child.description }}</span>{% endif -%}
+                      </a></li>
+                    {%- else -%}
+                      <li class="dropdown-header">{{ child.title }}</li>
+                    {%- endif -%}
+                  {%- endfor -%}
+                </ul>
+                {% endif %}
               {% else %}
-                <a href="{{ link.url | relative_url }}"{% if link.description %} title="{{ link.description }}"{% endif %}>{{ link.title }}</a>
+                {%- if link.url contains '://' -%}{%- assign _lhref = link.url -%}{%- else -%}{%- assign _lhref = link.url | relative_url -%}{%- endif -%}
+                <a href="{{ _lhref }}"{% if link.description %} title="{{ link.description }}"{% endif %}>{{ link.title }}</a>
               {% endif %}
             </li>
           {%- endfor -%}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -103,6 +103,54 @@ search: false
   z-index: 1001;
 }
 
+/* ---- Website-menu dropdown (Product): text toggle + sectioned links -------
+   Reuses the hover .dropdown-menu behaviour above; only the toggle chrome and
+   the two-line (name + platform) child rows are added here. Theme colours come
+   from the --surface/--border/--text/--accent vars used by .dropdown-menu. */
+.dropdown-toggle--text {
+  gap: 0.25rem;
+}
+.dropdown-toggle--text .dropdown-caret {
+  width: 14px;
+  height: 14px;
+  transition: transform 0.2s ease;
+}
+.masthead__menu-item:hover .dropdown-toggle--text .dropdown-caret {
+  transform: rotate(180deg);
+}
+.dropdown-menu--wide {
+  min-width: 240px;
+  padding: 0.4rem 0;
+}
+.dropdown-menu--wide .dropdown-header {
+  padding: 0.5rem 16px 0.25rem;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted, #8a8a8f);
+}
+.dropdown-menu--wide .dropdown-header:not(:first-child) {
+  margin-top: 0.25rem;
+  border-top: 1px solid var(--border, rgba(0, 0, 0, 0.08));
+  padding-top: 0.6rem;
+}
+.dropdown-menu--wide a {
+  padding: 6px 16px;
+}
+.dropdown-menu--wide .dropdown-name {
+  display: block;
+  font-weight: 500;
+  line-height: 1.3;
+}
+.dropdown-menu--wide .dropdown-desc {
+  display: block;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 1.3;
+  color: var(--text-muted, #8a8a8f);
+}
+
 /* 검색 링크 버튼 스타일 */
 .search__toggle {
   display: inline-flex;


### PR DESCRIPTION
## Why
Direct visits to `/tech-blog/*` (e.g. from social links) showed only the blog's
own masthead — logo + language switcher — with **no thakicloud.com website menu**,
so readers had no path to the main site. (David's request in Slack; the homepage
`/blog?blogPath=` iframe wrapper was the interim workaround.)

Per the team's chosen direction (in-template, not an embed), this adds the
homepage website menu to the blog masthead so the blog reads as the same site.

## What
- **`_data/navigation.yml`** — add **Product ▾** (sectioned *On-Prem AI Cloud* /
  *AI Cloud* with all 7 products), **Tech Blog**, **Company**, **Contact** to
  `ko` / `en` / `main`. Product + Company/Contact links are **absolute to
  `thakicloud.com`**; Tech Blog → blog home. The per-post **language switcher** is
  kept and marked `type: language`. Labels mirror the homepage nav (EN + KO).
- **`_includes/masthead.html`** — generalize the dropdown branch: `type: language`
  keeps the existing globe + same-post translation logic; any **other** dropdown
  renders a generic **text toggle + caret** with **section headers** and
  **name + platform** rows. Absolute child/link URLs bypass `relative_url`.
- **`assets/css/main.scss`** — styles for the Product dropdown (text toggle,
  caret rotate on hover, section headers, two-line rows), reusing the existing
  hover `.dropdown-menu` + theme vars.

## Verification
- `navigation.yml` validated with **Ruby Psych** (Jekyll's YAML parser) — parses;
  ko/en/main structure confirmed.
- Liquid branch reviewed (balanced language / generic / plain-link paths).
- ⚠️ **A full Jekyll build was NOT run locally** (system Ruby is 2.6; bundler
  unavailable) and the branch CI (`act-test`) doesn't build Jekyll. Since merge to
  `main` **auto-deploys to production**, please **build/preview locally before
  merging** (masthead renders on any `/tech-blog/**` page).

## Notes
- No content or config changes; masthead/nav/CSS only.
- Section grouping matches the homepage mega-menu; if a flat list is preferred,
  drop the two header rows in `navigation.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)