### PR TITLE
fix(ci): make auto-merge actually merge and fail loudly

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -3,6 +3,13 @@ name: Auto-merge approved PRs
 on:
   pull_request_review:
     types: [submitted]
+  # Manual path: re-run the gate for a PR that was approved while this
+  # workflow was broken, and a way to actually exercise the job end to end.
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: PR number to merge (must already be approved)
+        required: true
 
 permissions:
   contents: write
@@ -10,7 +17,7 @@ permissions:
   checks: read
 
 concurrency:
-  group: auto-merge-pr-${{ github.event.pull_request.number }}
+  group: auto-merge-pr-${{ github.event.pull_request.number || github.event.inputs.pr }}
   cancel-in-progress: false
 
 jobs:
@@ -18,23 +25,55 @@ jobs:
     name: 🤖 Auto-merge approved PRs
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Skip the noise of non-approving reviews; every real gate is re-checked
+    # in the resolve step below, against live state rather than the payload.
     if: >-
-      github.event.review.state == 'approved' &&
-      github.event.pull_request.draft == false &&
-      github.event.pull_request.state == 'open'
+      github.event_name == 'workflow_dispatch' ||
+      github.event.review.state == 'approved'
 
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GH_REPO: ${{ github.repository }}
-      PR: ${{ github.event.pull_request.number }}
-      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-      HEAD_REF: ${{ github.event.pull_request.head.ref }}
-      HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-      # This job posts its own check run against HEAD_SHA; excluded when polling
-      # so it never waits on itself.
+      # This job posts its own check run against the PR head; excluded when
+      # polling so it never waits on itself.
       SELF_CHECK_NAME: 🤖 Auto-merge approved PRs
 
     steps:
+      - name: 🔍 Resolve the PR and confirm it is still mergeable
+        env:
+          PR: ${{ github.event.pull_request.number || github.event.inputs.pr }}
+        run: |
+          set -euo pipefail
+
+          # Read live state instead of trusting the event payload: an approval
+          # can be dismissed by a later push (dismiss_stale_reviews_on_push),
+          # and a dispatch carries no review information at all.
+          pr_json=$(gh pr view "$PR" --json \
+            state,isDraft,reviewDecision,headRefName,headRefOid,headRepository,headRepositoryOwner)
+
+          field() { printf '%s' "$pr_json" | jq -r "$1"; }
+          state=$(field '.state')
+          draft=$(field '.isDraft | tostring')
+          decision=$(field '.reviewDecision // "NONE"')
+          head_sha=$(field '.headRefOid')
+          head_ref=$(field '.headRefName')
+          head_repo=$(field '"\(.headRepositoryOwner.login)/\(.headRepository.name)"')
+
+          echo "PR #${PR}: state=${state} draft=${draft} review=${decision} head=${head_ref}@${head_sha:0:7}"
+
+          [ "$state" = "OPEN" ]      || { echo "PR is ${state}; nothing to do."; exit 0; }
+          [ "$draft" = "false" ]     || { echo "PR is a draft; nothing to do."; exit 0; }
+          # The review gate is enforced here, not bypassed by workflow_dispatch.
+          [ "$decision" = "APPROVED" ] || {
+            echo "::error::PR #${PR} is not approved (reviewDecision=${decision})."; exit 1; }
+
+          {
+            echo "PR=$PR"
+            echo "HEAD_SHA=$head_sha"
+            echo "HEAD_REF=$head_ref"
+            echo "HEAD_REPO=$head_repo"
+          } >> "$GITHUB_ENV"
+
       - name: ⏳ Wait for the other checks on the PR head
         run: |
           set -euo pipefail
@@ -45,7 +84,8 @@ jobs:
               --paginate --jq '.check_runs[] | select(.name != env.SELF_CHECK_NAME)
                                | "\(.status)\t\(.conclusion // "")\t\(.name)"')
 
-            # Any hard failure ends this immediately - do not merge a red PR.
+            # Any hard failure ends this immediately - never merge a red PR.
+            # skipped and neutral are pass-equivalent and do not block.
             if failed=$(printf '%s\n' "$runs" \
               | awk -F'\t' '$2 ~ /^(failure|cancelled|timed_out|startup_failure)$/ {print "  - " $3 " (" $2 ")"}' \
               | grep .); then
@@ -76,24 +116,17 @@ jobs:
       - name: 🔀 Squash-merge the approved PR
         run: |
           set -euo pipefail
-          # Re-read state: the review that triggered us may be stale by now
-          # (a push dismisses reviews, someone may have merged or closed it).
-          state=$(gh pr view "$PR" --json state --jq .state)
-          if [ "$state" != "OPEN" ]; then
-            echo "PR #${PR} is ${state}; nothing to merge."
-            exit 0
-          fi
-
-          # gh exits non-zero on unresolved review threads, conflicts, or a
-          # dismissed approval. That failure is the point - surface it.
+          # Squash matches the ruleset's allowed_merge_methods. gh exits
+          # non-zero on unresolved review threads, conflicts, or a dismissed
+          # approval - that failure is the point, so it is not swallowed.
           gh pr merge "$PR" --squash
 
       - name: 🧹 Tidy up after the merge
         if: success()
         continue-on-error: true
         run: |
-          # Cosmetic only: never fail a completed merge over a label or a
-          # branch that lives in a fork we cannot delete.
+          # Cosmetic only: never fail a completed merge over a label, or over
+          # a branch living in a fork we have no write access to.
           gh pr edit "$PR" --add-label auto-merge || true
           if [ "$HEAD_REPO" = "$GH_REPO" ]; then
             gh api -X DELETE "repos/${GH_REPO}/git/refs/heads/${HEAD_REF}" || true

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -7,41 +7,94 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  checks: read
+
+concurrency:
+  group: auto-merge-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
 
 jobs:
   auto-merge:
     name: 🤖 Auto-merge approved PRs
     runs-on: ubuntu-latest
-    if: github.event.review.state == 'approved'
+    timeout-minutes: 30
+    if: >-
+      github.event.review.state == 'approved' &&
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.state == 'open'
+
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      PR: ${{ github.event.pull_request.number }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      HEAD_REF: ${{ github.event.pull_request.head.ref }}
+      HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+      # This job posts its own check run against HEAD_SHA; excluded when polling
+      # so it never waits on itself.
+      SELF_CHECK_NAME: 🤖 Auto-merge approved PRs
 
     steps:
-      - name: 🤖 Enable auto-merge for approved PRs
-        uses: actions/github-script@v8
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { owner, repo } = context.repo;
-            const pull_number = context.payload.pull_request.number;
-            
-            try {
-              // Enable auto-merge with squash
-              await github.rest.pulls.enableAutoMerge({
-                owner,
-                repo,
-                pull_number,
-                merge_method: 'squash'
-              });
-              
-              console.log(`Auto-merge enabled for PR #${pull_number}`);
-              
-              // Add auto-merge label
-              await github.rest.issues.addLabels({
-                issue_number: pull_number,
-                owner,
-                repo,
-                labels: ['auto-merge']
-              });
-              
-            } catch (error) {
-              console.error('Failed to enable auto-merge:', error.message);
-            } 
+      - name: ⏳ Wait for the other checks on the PR head
+        run: |
+          set -euo pipefail
+          deadline=$(( SECONDS + 20 * 60 ))
+
+          while :; do
+            runs=$(gh api "repos/${GH_REPO}/commits/${HEAD_SHA}/check-runs" \
+              --paginate --jq '.check_runs[] | select(.name != env.SELF_CHECK_NAME)
+                               | "\(.status)\t\(.conclusion // "")\t\(.name)"')
+
+            # Any hard failure ends this immediately - do not merge a red PR.
+            if failed=$(printf '%s\n' "$runs" \
+              | awk -F'\t' '$2 ~ /^(failure|cancelled|timed_out|startup_failure)$/ {print "  - " $3 " (" $2 ")"}' \
+              | grep .); then
+              echo "::error::PR #${PR} has failing checks; refusing to merge."
+              printf '%s\n' "$failed"
+              exit 1
+            fi
+
+            pending=$(printf '%s\n' "$runs" \
+              | awk -F'\t' '$1 != "completed" && NF {print "  - " $3 " (" $1 ")"}' || true)
+
+            if [ -z "$pending" ]; then
+              echo "All checks on ${HEAD_SHA} are complete."
+              break
+            fi
+
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "::error::Timed out after 20m waiting for checks on PR #${PR}."
+              printf '%s\n' "$pending"
+              exit 1
+            fi
+
+            echo "Waiting on:"
+            printf '%s\n' "$pending"
+            sleep 15
+          done
+
+      - name: 🔀 Squash-merge the approved PR
+        run: |
+          set -euo pipefail
+          # Re-read state: the review that triggered us may be stale by now
+          # (a push dismisses reviews, someone may have merged or closed it).
+          state=$(gh pr view "$PR" --json state --jq .state)
+          if [ "$state" != "OPEN" ]; then
+            echo "PR #${PR} is ${state}; nothing to merge."
+            exit 0
+          fi
+
+          # gh exits non-zero on unresolved review threads, conflicts, or a
+          # dismissed approval. That failure is the point - surface it.
+          gh pr merge "$PR" --squash
+
+      - name: 🧹 Tidy up after the merge
+        if: success()
+        continue-on-error: true
+        run: |
+          # Cosmetic only: never fail a completed merge over a label or a
+          # branch that lives in a fork we cannot delete.
+          gh pr edit "$PR" --add-label auto-merge || true
+          if [ "$HEAD_REPO" = "$GH_REPO" ]; then
+            gh api -X DELETE "repos/${GH_REPO}/git/refs/heads/${HEAD_REF}" || true
+          fi


### PR DESCRIPTION
## Problem

`Auto-merge approved PRs` has never merged anything, while reporting **success** on every run.

Two independent bugs:

1. **`github.rest.pulls.enableAutoMerge` does not exist.** Auto-merge is a GraphQL-only mutation (`enablePullRequestAutoMerge`); there is no REST equivalent, so the call threw on every invocation.
2. **The `catch` swallowed it.** The error went to `console.error` and the step still exited 0, so the check turned green and the failure stayed invisible.

Observed on #124 (run [31068590227](https://github.com/ThakiCloud/thakicloud.github.io/actions/runs/31068590227)): `Failed to enable auto-merge: github.rest.pulls.enableAutoMerge is not a function`, job conclusion `success`. That PR had to be merged by hand.

## Why not just fix the GraphQL call

`allow_auto_merge` is **disabled** on this repo, so the corrected mutation would still fail. Enabling it would not help either: GitHub's auto-merge waits for *required* status checks, and the `Protect: main branch` ruleset requires **1 approving review and no status checks at all**. Auto-merge would therefore fire the instant an approval landed, without ever looking at `Simple Test`.

So this replaces the queue with an explicit gate that does what the workflow's name implies.

## What it does now

1. **Resolves live PR state** rather than trusting the event payload, and re-checks every gate: open, not a draft, `reviewDecision == APPROVED`. A push dismisses reviews under `dismiss_stale_reviews_on_push`, so the approval that triggered the run can already be stale by the time it executes. Closed or merged PRs exit 0 quietly; an unapproved one is a hard error.
2. **Waits on the PR head's check runs**, excluding its own. Exits non-zero on `failure` / `cancelled` / `timed_out` / `startup_failure`; `skipped` and `neutral` are pass-equivalent; 20-minute ceiling instead of hanging.
3. **Squash-merges**, matching the ruleset's `allowed_merge_methods: [squash, rebase]`. `gh` exits non-zero on unresolved threads, conflicts, or a dismissed approval, and that failure is now surfaced instead of buried.
4. **Labels and deletes the branch in a separate `continue-on-error` step**, so nothing cosmetic can fail an already-completed merge. Branch deletion is skipped for forks. The `auto-merge` label has been created in the repo — the old code would have 422'd on it.

Also adds a `workflow_dispatch` path taking a PR number, so a PR approved while this was broken can be merged without hand-running `gh`, and so the job can be exercised end to end. **It is not a bypass**: dispatch runs go through the same `reviewDecision == APPROVED` check.

## Verification

- `actionlint` (which runs `shellcheck` over the `run:` blocks) — clean.
- Resolve step run against live PRs: #125 (open, unapproved) → hard error, dispatch cannot skip review; #124 (merged) → graceful exit 0.
- Self-exclusion filter run against #124's head SHA: 2 check runs in, only `🧪 Simple Test` out.
- Wait loop run against a real all-green SHA — exits 0.
- Gate logic table-tested over 8 states: all-green, single failure, `in_progress`, `queued`, `cancelled`, no-checks-at-all, `skipped`, `neutral`. Each takes the intended branch.

One honest caveat: `pull_request_review` workflows run from the **base branch**, so approving *this* PR still executes the old broken file. The first real end-to-end proof is the next PR approved after this merges, or a manual `workflow_dispatch` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
