### PR TITLE
fix(ci): stop later steps when the PR needs no merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -40,6 +40,7 @@ jobs:
 
     steps:
       - name: 🔍 Resolve the PR and confirm it is still mergeable
+        id: resolve
         env:
           PR: ${{ github.event.pull_request.number || github.event.inputs.pr }}
         run: |
@@ -61,12 +62,17 @@ jobs:
 
           echo "PR #${PR}: state=${state} draft=${draft} review=${decision} head=${head_ref}@${head_sha:0:7}"
 
-          [ "$state" = "OPEN" ]      || { echo "PR is ${state}; nothing to do."; exit 0; }
-          [ "$draft" = "false" ]     || { echo "PR is a draft; nothing to do."; exit 0; }
+          # `exit 0` only ends this step, not the job, so nothing-to-do has to
+          # be published as an output that the later steps gate on.
+          skip() { echo "$1"; echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0; }
+
+          [ "$state" = "OPEN" ]  || skip "PR is ${state}; nothing to do."
+          [ "$draft" = "false" ] || skip "PR is a draft; nothing to do."
           # The review gate is enforced here, not bypassed by workflow_dispatch.
           [ "$decision" = "APPROVED" ] || {
             echo "::error::PR #${PR} is not approved (reviewDecision=${decision})."; exit 1; }
 
+          echo "skip=false" >> "$GITHUB_OUTPUT"
           {
             echo "PR=$PR"
             echo "HEAD_SHA=$head_sha"
@@ -75,6 +81,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: ⏳ Wait for the other checks on the PR head
+        if: steps.resolve.outputs.skip != 'true'
         run: |
           set -euo pipefail
           deadline=$(( SECONDS + 20 * 60 ))
@@ -114,6 +121,7 @@ jobs:
           done
 
       - name: 🔀 Squash-merge the approved PR
+        if: steps.resolve.outputs.skip != 'true'
         run: |
           set -euo pipefail
           # Squash matches the ruleset's allowed_merge_methods. gh exits
@@ -122,7 +130,7 @@ jobs:
           gh pr merge "$PR" --squash
 
       - name: 🧹 Tidy up after the merge
-        if: success()
+        if: success() && steps.resolve.outputs.skip != 'true'
         continue-on-error: true
         run: |
           # Cosmetic only: never fail a completed merge over a label, or over


### PR DESCRIPTION
Follow-up to #125, caught by actually dispatching the workflow rather than reading it.

## Bug

The resolve step's `exit 0` for a closed/merged/draft PR ends **the step, not the job**. The remaining steps still ran, and `⏳ Wait` immediately died on `HEAD_SHA: unbound variable` (`set -u`), so a no-op turned into a red run.

Reproduced live: [run 31070340540](https://github.com/ThakiCloud/thakicloud.github.io/actions/runs/31070340540) dispatched against the already-merged #124 printed `PR is MERGED; nothing to do.` and then failed.

## Fix

Resolve now publishes `skip=true` to `$GITHUB_OUTPUT`, and the wait / merge / tidy steps carry `if: steps.resolve.outputs.skip != 'true'`. A genuine no-op ends green; a real problem (unapproved, red checks, unresolved threads) still fails loudly.

Nothing else changes — this is only the early-exit path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)