### PR TITLE
fix(ci): dispatch the deploy after an auto-merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -15,6 +15,7 @@ permissions:
   contents: write
   pull-requests: write
   checks: read
+  actions: write   # dispatch the deploy the merge itself cannot trigger
 
 concurrency:
   group: auto-merge-pr-${{ github.event.pull_request.number || github.event.inputs.pr }}
@@ -128,6 +129,17 @@ jobs:
           # non-zero on unresolved review threads, conflicts, or a dismissed
           # approval - that failure is the point, so it is not swallowed.
           gh pr merge "$PR" --squash
+
+      - name: 🚀 Trigger the deploy that the merge cannot
+        if: steps.resolve.outputs.skip != 'true'
+        run: |
+          set -euo pipefail
+          # A merge made with GITHUB_TOKEN raises no `push` event, so jekyll.yml
+          # never sees it and the site silently goes stale - which is exactly
+          # what happened to #117, #120 and #123. workflow_dispatch is not
+          # subject to that recursion guard (verified: GITHUB_TOKEN created a
+          # real dispatch run), so ask for the deploy explicitly.
+          gh workflow run jekyll.yml --ref main
 
       - name: 🧹 Tidy up after the merge
         if: success() && steps.resolve.outputs.skip != 'true'


### PR DESCRIPTION
Third defect in this chain, and the only one that reached production.

## Problem

GitHub does not start a workflow from an event raised with `GITHUB_TOKEN` — a recursion guard. The auto-merge workflow merges with that token, so its push to `main` never fires `jekyll.yml`.

This was invisible until auto-merge actually started working. #120, #117 and #123 all landed on `main` and **none of them deployed**. Confirmed against production: `main.scss:231` on `main` carries `overflow-y: scroll` from #123, while `https://thakicloud.com/tech-blog/assets/css/main.css` contained zero occurrences of it. The site was stale and nothing reported a failure — the same silent-success shape as the original bug.

(Production has since been brought current with a manual dispatch.)

## Fix

After a successful merge, ask for the deploy explicitly:

```
gh workflow run jekyll.yml --ref main
```

plus `actions: write`. If the dispatch fails the job fails — it is not swallowed.

`workflow_dispatch` is not subject to the recursion guard, but I did not want to rely on my reading of the docs, so I measured it: a throwaway probe workflow called `gh workflow run` with nothing but `GITHUB_TOKEN`, and it produced [run 31075276207](https://github.com/ThakiCloud/thakicloud.github.io/actions/runs/31075276207) — `event: workflow_dispatch`, actor `github-actions[bot]`, conclusion success. The probe branch has been deleted.

## Note on ordering

The deploy is dispatched before the cosmetic tidy step, so a label or branch-deletion hiccup can never cost a deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)